### PR TITLE
Fixed `Response Validation` state to correctly point to `Nino check s…

### DIFF
--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -228,40 +228,32 @@
         {
           "And": [
             {
-              "Not": {
-                "Variable": "$.result.firstName",
-                "IsPresent": true
-              }
+              "Variable": "$.firstName",
+              "IsPresent": true
             },
             {
-              "Not": {
-                "Variable": "$.result.lastName",
-                "IsPresent": true
-              }
+              "Variable": "$.lastName",
+              "IsPresent": true
             },
             {
-              "Not": {
-                "Variable": "$.result.dateOfBirth",
-                "IsPresent": true
-              }
+              "Variable": "$.dateOfBirth",
+              "IsPresent": true
             },
             {
-              "Not": {
-                "Variable": "$.result.nino",
-                "IsPresent": true
-              }
+              "Variable": "$.nino",
+              "IsPresent": true
             }
           ],
-          "Next": "Error: HMRC came back with an error"
+          "Next": "Nino check successful"
         }
       ],
-      "Default": "Nino check successful"
+      "Default": "Error: HMRC came back with an error"
     },
-    "Error: HMRC came back with an error": {
+    "Nino check successful": {
       "Type": "Pass",
       "End": true
     },
-    "Nino check successful": {
+    "Error: HMRC came back with an error": {
       "Type": "Pass",
       "End": true
     }


### PR DESCRIPTION
…uccessful`

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
ASL for state machine.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
During a happy path test, the response validation was not hitting the nino check success state but was always going to the error state. This was because the validation rule was incorrect. 

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
