### PR TITLE
OJ-1901: Added create authorization code to nino step function

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -354,6 +354,20 @@ Resources:
         EntryPoints:
           - src/time-handler.ts
 
+  CreateAuthCodeFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../lambdas/issue-credential
+      Handler: create-auth-code-handler.lambdaHandler
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2020"
+        Sourcemap: true
+        EntryPoints:
+          - src/create-auth-code-handler.ts
+
   NinoCheckStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
@@ -361,12 +375,14 @@ Resources:
       Type: EXPRESS
       DefinitionUri: ../step-functions/nino_check.asl.json
       DefinitionSubstitutions:
+        CreateAuthCodeFunctionArn: !GetAtt CreateAuthCodeFunction.Arn
         MatchingFunctionArn: !GetAtt MatchingFunction.Arn
         NinoAttemptsTable: !Ref NinoAttemptsTable
         NinoUsersTable: !Ref NinoUsersTable
         NinoCheckUrl: !Ref NinoCheckUrl
         UserAgent: !Ref UserAgent
         BearerTokenName: !Ref BearerTokenName
+        CommonStackName: !Ref CommonStackName
       Logging:
         Destinations:
           - CloudWatchLogsLogGroup:
@@ -375,7 +391,13 @@ Resources:
         Level: ALL
       Policies:
         - LambdaInvokePolicy:
+            FunctionName: !Ref CreateAuthCodeFunction
+        - LambdaInvokePolicy:
             FunctionName: !Ref MatchingFunction
+        - DynamoDBReadPolicy:
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+        - DynamoDBWritePolicy:
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
         - DynamoDBWritePolicy:
             TableName: !Ref NinoAttemptsTable
         - DynamoDBReadPolicy:
@@ -392,6 +414,7 @@ Resources:
             Resource:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/NinoCheckUrl"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/UserAgent"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
         - Statement:
             Effect: Allow
             Action:
@@ -467,6 +490,12 @@ Resources:
       RetentionInDays: 30
 
 Outputs:
+  CreateAuthCodeFunction:
+    Description: "Create Authorization Code Function ARN"
+    Value: !GetAtt CreateAuthCodeFunction.Arn
+  CreateAuthCodeFunctionRoleArn:
+    Description: "Create Authorization Code Function Arn"
+    Value: !GetAtt CreateAuthCodeFunctionRole.Arn
   TimeFunction:
     Description: "Time Lambda Function ARN"
     Value: !GetAtt TimeFunction.Arn

--- a/lambdas/issue-credential/src/create-auth-code-handler.ts
+++ b/lambdas/issue-credential/src/create-auth-code-handler.ts
@@ -1,0 +1,23 @@
+import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { Logger } from "@aws-lambda-powertools/logger";
+
+const logger = new Logger();
+const DEFAULT_AUTHORIZATION_CODE_TTL_IN_MILLIS = 600 * 1000;
+
+export class CreateAuthCodeHandler implements LambdaInterface {
+  public async handler(_event: unknown, _context: unknown): Promise<any> {
+    try {
+      return {
+        authCodeExpiry: Math.floor(
+          (Date.now() + DEFAULT_AUTHORIZATION_CODE_TTL_IN_MILLIS) / 1000
+        ),
+      };
+    } catch (error: any) {
+      logger.error("Error in CreateAuthCodeHandler: " + error.message);
+      throw error;
+    }
+  }
+}
+
+const handlerClass = new CreateAuthCodeHandler();
+export const lambdaHandler = handlerClass.handler.bind(handlerClass);

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -269,6 +269,60 @@
           }
         }
       },
+      "Next": "Fetch Auth Code Expiry"
+    },
+    "Fetch Auth Code Expiry": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "OutputPath": "$.Payload",
+      "Parameters": {
+        "Payload.$": "$",
+        "FunctionName": "${CreateAuthCodeFunctionArn}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Fetch Session Table Name"
+    },
+    "Fetch Session Table Name": {
+      "Type": "Task",
+      "Next": "Set  Auth Code for Session",
+      "Parameters": {
+        "Name": "/${CommonStackName}/SessionTableName"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
+      "ResultPath": "$.sessionTable"
+    },
+    "Set Auth Code for Session": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Parameters": {
+        "TableName.$": "$.sessionTable.Parameter.Name",
+        "Key": {
+          "sessionId": {
+            "S.$": "$$.Execution.Input.sessionId"
+          }
+        },
+        "UpdateExpression": "SET authorizationCode = :authCode, authorizationCodeExpiryDate = :expiry",
+        "ExpressionAttributeValues": {
+          ":authCode": {
+            "S.$": "States.UUID()"
+          },
+          ":expiry": {
+            "N.$": "States.Format('{}',$.authCodeExpiry)"
+          }
+        }
+      },
       "Next": "Nino check successful"
     },
     "Nino check successful": {


### PR DESCRIPTION
## Proposed changes

Adding authorizationCode logic to NINO check state machine

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change
As part of the OAuth flow we need an auth code

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1901](https://govukverify.atlassian.net/browse/OJ-1901)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
