### PR TITLE
[BAU] NINO Check State Machine to use Person Identity table

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -404,6 +404,10 @@ Resources:
             TableName: !Ref NinoAttemptsTable
         - DynamoDBReadPolicy:
             TableName: !Ref NinoUsersTable
+        - DynamoDBWritePolicy:
+            TableName: !Ref NinoUsersTable
+        - DynamoDBReadPolicy:
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${BearerTokenName}-??????
         - Statement:
@@ -415,6 +419,7 @@ Resources:
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/NinoCheckUrl"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/UserAgent"
               - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
         - Statement:
             Effect: Allow
             Action:

--- a/lambdas/matching/src/matching-handler.ts
+++ b/lambdas/matching/src/matching-handler.ts
@@ -14,9 +14,9 @@ export class MatchingHandler implements LambdaInterface {
           Authorization: "Bearer " + event.oAuthToken,
         },
         body: JSON.stringify({
-          firstName: event.userDetails.firstName.S,
-          lastName: event.userDetails.lastName.S,
-          dateOfBirth: event.userDetails.dob.S,
+          firstName: event.userDetails.firstName,
+          lastName: event.userDetails.lastName,
+          dateOfBirth: event.userDetails.dob,
           nino: event.nino,
         }),
       });

--- a/step-functions/nino_check.asl.json
+++ b/step-functions/nino_check.asl.json
@@ -85,16 +85,8 @@
         {
           "And": [
             {
-              "Not": {
-                "Variable": "$.check-attempts-exist.Items[0].attempts.N",
-                "StringEquals": "0"
-              }
-            },
-            {
-              "Not": {
-                "Variable": "$.check-attempts-exist.Items[0].attempts.N",
-                "StringEquals": "1"
-              }
+              "Variable": "$.check-attempts-exist.Items[0].attempts.N",
+              "StringGreaterThanEquals": "2"
             }
           ],
           "Next": "Error: Maximum number of attempts exceeded"
@@ -119,18 +111,27 @@
           }
         }
       },
-      "Next": "Query user from nino",
+      "Next": "Fetch Person Identity Table Name",
       "ResultPath": null
     },
-    "Query user from nino": {
+    "Fetch Person Identity Table Name": {
+      "Type": "Task",
+      "Next": "Query user by sessionId",
+      "Parameters": {
+        "Name": "/${CommonStackName}/PersonIdentityTableName"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
+      "ResultPath": "$.personIdentityTableName"
+    },
+    "Query user by sessionId": {
       "Type": "Task",
       "Next": "Check user details exist for given nino",
       "Parameters": {
-        "TableName": "${NinoUsersTable}",
-        "KeyConditionExpression": "nino = :value",
+        "TableName.$": "$.personIdentityTableName.Parameter.Value",
+        "KeyConditionExpression": "sessionId = :value",
         "ExpressionAttributeValues": {
           ":value": {
-            "S.$": "$.nino"
+            "S.$": "$.sessionId"
           }
         }
       },
@@ -204,7 +205,11 @@
       "Parameters": {
         "sessionId.$": "$.sessionId",
         "nino.$": "$.nino",
-        "userDetails.$": "$.userDetails.Items[0]",
+        "userDetails": {
+          "firstName.$": "$.userDetails.Items[0].names.L[0].M.nameParts.L[0].M.value.S",
+          "lastName.$": "$.userDetails.Items[0].names.L[0].M.nameParts.L[1].M.value.S",
+          "dob.$": "$.userDetails.Items[0].birthDates.L[0].M.value.S"
+        },
         "userAgent.$": "$.userAgent.value",
         "apiURL.$": "$.apiURL.value",
         "oAuthToken.$": "$.oAuthToken.value"
@@ -326,8 +331,26 @@
           }
         }
       },
-      "Next": "Nino check successful",
+      "Next": "Save NINO & sessionId to nino-users table",
       "ResultPath": "$.setAuthCode"
+    },
+    "Save NINO & sessionId to nino-users table": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:putItem",
+      "Parameters": {
+        "TableName": "${NinoUsersTable}",
+        "Item": {
+          "sessionId": {
+            "S.$": "$$.Execution.Input.sessionId"
+          },
+          "nino": {
+            "S.$": "$.hmrc_response.nino"
+          }
+        },
+        "ConditionExpression": "attribute_not_exists(sessionId)"
+      },
+      "Next": "Nino check successful",
+      "ResultPath": "$.saveUser"
     },
     "Nino check successful": {
       "Type": "Pass",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
The state machine ASL to grab the person identity table name and to save the nino+sessionId to the nino-users table.
<!-- Describe the changes in detail - the "what"-->

### Why did it change
We originally used the nino-users table as a temp placeholder for the person identity table. Now that common-lambas in there, this table has been repurposed to store the users nino which it then later used to generate a VC.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
