### PR TITLE
BAU: Exclude package-lock from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     rev: v3.2.0
     hooks:
       - id: check-added-large-files
+        exclude: package-lock.json
       - id: check-case-conflict
       - id: detect-private-key
       - id: end-of-file-fixer


### PR DESCRIPTION
## Proposed changes

Exclude package-lock.json from pre-commit large file checks